### PR TITLE
Configure to load js as ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "minesweeper",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check build-only",


### PR DESCRIPTION
Configured `package.json` to work around [Vite's deprecation warning](https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated)
- https://nodejs.org/api/packages.html#type
  > Files ending with `.js` are loaded as ES modules